### PR TITLE
Learning Corpus updates (Part I)

### DIFF
--- a/modelingassistant.learningcorpus.dsl.instances/default.learningcorpus
+++ b/modelingassistant.learningcorpus.dsl.instances/default.learningcorpus
@@ -1,155 +1,155 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<learningcorpus:LearningCorpus xmlns:xmi="http://www.omg.org/XMI" xmlns:learningcorpus="http://cs.mcgill.ca/sel/modelingassistant/learningcorpus/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmi:id="0f89e6cf-4ba8-4946-92cc-3fb405f97b62" xmi:version="2.0">
-  <learningItems xsi:type="learningcorpus:LearningItem" xmi:id="40b4b3e0-59bf-4c04-9ec0-e28cd0e12bb4" name="DomainModeling"/>
-  <learningResources xsi:type="learningcorpus:Example" xmi:id="793d6d0f-6d6b-45c8-92c5-9c4274a1064e" content="Please note these examples of correct vs incorrect class naming:&#10;:x: Examples to avoid | :heavy_check_mark: Good class names&#10;--- | ---&#10;pilot | Pilot&#10;Airplanes | Airplane &#10;AirlineData | Airline" resourceResponses="dbaea525-513b-4b4e-8b0b-6f7890bff171"/>
-  <mistakeTypeCategories xsi:type="learningcorpus:MistakeTypeCategory" xmi:id="896b9d6a-9c22-4c6d-adb7-cc93f2fe3095" name="Class mistakes" subcategories="075a86b2-4d0e-4ef6-b795-b1d1d191cbd7 3676ad67-4716-46d7-99ab-608f2f1c35fc">
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="ce5da776-30ee-426c-aa5e-1ef578cda2da" name="Missing class" priority="82" description="Missing class" feedbacks="400e1fdd-991a-407e-ae6f-299c43ad9067 5482bf85-9262-4662-a9bf-21a4cab1a636 c940cc7a-b64b-431e-a07d-e0288ff36b49 3b9f7533-7ed8-4c08-9fb1-1aa09b2b933a"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="0e6a436c-a8b1-40fa-b00b-29d1a7cc314a" name="Extra (redundant) class" description="Extra (redundant) class" priority="70"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="4725e143-9115-481f-88c7-cc576e143d54" name="Using n-ary assoc instead of intermediate class" description="Using n-ary association instead of intermediate class" priority="39"/>
+<learningcorpus:LearningCorpus xmlns:xmi="http://www.omg.org/XMI" xmlns:learningcorpus="http://cs.mcgill.ca/sel/modelingassistant/learningcorpus/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmi:id="7f68e9db-bf97-4d87-98cf-6ab42210a064" xmi:version="2.0">
+  <learningItems xsi:type="learningcorpus:LearningItem" xmi:id="f1932d36-e203-4296-a828-50aa159661ee" name="DomainModeling"/>
+  <learningResources xsi:type="learningcorpus:Example" xmi:id="f8d2c909-18d0-4339-9ea6-ba51664d7a75" content="Please note these examples of correct vs incorrect class naming:&#10;:x: Examples to avoid | :heavy_check_mark: Good class names&#10;--- | ---&#10;pilot | Pilot&#10;Airplanes | Airplane &#10;AirlineData | Airline" resourceResponses="65020d68-1a83-412e-a06c-e38961d3a096"/>
+  <mistakeTypeCategories xsi:type="learningcorpus:MistakeTypeCategory" xmi:id="b31a9f23-222e-407d-bdc6-10c8ec3e27c5" name="Class mistakes" subcategories="8d72fe7f-4b46-46b8-bd89-9053127aec11 86ba721d-9858-41df-811a-ca50d807a9e5">
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="530aaaf1-64c9-4580-99ce-e2a3738323cc" name="Missing class" priority="82" description="Missing class" feedbacks="338d5586-ff53-47a1-839c-548135106672 87a656de-ddf5-432e-9fc8-a01ee89c449c 7ae0fe18-6999-4c05-ad4a-039689454e5a 3da0d6c1-4a5c-40df-bc87-f09338cd8a2e"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="6e6f0891-057c-46a6-80b7-b089ef8568c8" name="Extra (redundant) class" description="Extra (redundant) class" priority="70"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="696d7217-eb11-4a14-ae12-53afb00ca31b" name="Using n-ary assoc instead of intermediate class" description="Using n-ary association instead of intermediate class" priority="39"/>
   </mistakeTypeCategories>
-  <mistakeTypeCategories xsi:type="learningcorpus:MistakeTypeCategory" xmi:id="49ca5132-bf3a-4a9b-a6c6-4ae984fad5b2" name="Attribute mistakes" subcategories="6b5c70ef-a6d6-4bf4-9564-ee07adf21f53 ca815b3b-891f-420b-867b-2f221c419b5c 5ac746b4-b118-4564-9424-8692b44d1e4a">
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="e165d214-56c6-40a0-917e-0ec84287ebc4" name="Missing attribute" description="Missing attribute" priority="83"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="f11f2570-dc04-47d9-a909-89cfd28fa823" name="Wrong attribute type" description="Wrong attribute type" priority="22"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="babdffef-1908-4861-8c54-4f361063440b" name="Missing attribute type" description="Missing attribute type" priority="84"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="2cd3e2c0-b289-4640-b7c4-f237a866ab21" name="Attribute should be static" description="Attribute should be static" priority="24"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="fb8019f3-5d54-4127-a696-17aae22f3ed7" name="Attribute should not be static" description="Attribute should not be static" priority="23"/>
+  <mistakeTypeCategories xsi:type="learningcorpus:MistakeTypeCategory" xmi:id="2898ce55-93b3-406f-9720-0920e2fb89b8" name="Attribute mistakes" subcategories="61f4ec2c-0112-403e-a722-0ec17b599002 6364c3bd-1053-4a7c-aa79-68bd689427cc f7144ce9-ccc4-418e-9916-ec74f26806da">
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="68518f4c-fea2-488e-8f1b-2edc39a7f8aa" name="Missing attribute" description="Missing attribute" priority="83"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="f0b800dd-88ba-4139-af09-0827449e8ca0" name="Wrong attribute type" description="Wrong attribute type" priority="22"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="4cdc030a-5dd6-4978-9cc4-b9effff53201" name="Missing attribute type" description="Missing attribute type" priority="84"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="4ab29c09-ad23-418f-a7f2-e525839dae92" name="Attribute should be static" description="Attribute should be static" priority="24"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="f5dc8826-dfa1-4451-b121-2e3a9107d0e1" name="Attribute should not be static" description="Attribute should not be static" priority="23"/>
   </mistakeTypeCategories>
-  <mistakeTypeCategories xsi:type="learningcorpus:MistakeTypeCategory" xmi:id="6cb11c42-b499-49d0-a79e-562307e79b70" name="Relationship mistakes" subcategories="01925285-d1d6-4e9f-a913-7743377d1543 1f32caa0-8baa-4c01-8db3-04e2ce461269 e4ab00e6-f548-47e8-9520-f14f0aa9df86"/>
-  <mistakeTypeCategories xsi:type="learningcorpus:MistakeTypeCategory" xmi:id="b9cbe39b-6226-499e-aa27-bdac3dadf059" name="Design pattern mistakes" subcategories="c3c80734-4295-4c3c-8860-531118769d36 14c8fec2-ac91-428b-bcaa-0af0597a45fa"/>
-  <mistakeTypeCategories xsi:type="learningcorpus:MistakeTypeCategory" xmi:id="075a86b2-4d0e-4ef6-b795-b1d1d191cbd7" name="Class name mistakes" supercategory="896b9d6a-9c22-4c6d-adb7-cc93f2fe3095">
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="4430da31-b22c-46af-9312-7dc31bf8eee3" name="Plural class name" description="Plural class name" priority="3"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="415a19da-b21f-49b9-b722-e70bac27da9d" name="Lowercase class name" description="Lowercase class name" priority="2"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="19f765f4-d93b-4eae-9ed5-5d285e4d8b09" name="Software engineering term" priority="4" atomic="true" description="Software engineering term" feedbacks="0b5384d8-35de-40bf-a24f-26c1895ce916 bc609090-604a-4c02-8146-24eebcd3ab51 f0c6a95c-959c-46b2-aa35-15b27f912946 dbaea525-513b-4b4e-8b0b-6f7890bff171"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="64e215eb-3162-4ab2-b1ed-ad62e1a89108" name="Bad class name spelling" priority="1" atomic="true" description="Bad class name spelling" feedbacks="4cddbd28-210a-4ba8-b898-92326286f98f ee7d0cc5-d636-42c7-95ab-2c0e0fab6e1f e4df4813-371d-460e-b5e6-7212abd8ec79 41cff1b2-d5b3-4562-b644-f304b42a0f3a"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="7bf38653-28dc-4b20-8d72-f1024ea73228" name="Similar (yet incorrect) class name" description="Similar (yet incorrect) class name" priority="5"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="8c63e762-085a-4639-a889-dd635807425d" name="Wrong class name" description="Wrong class name" priority="6"/>
+  <mistakeTypeCategories xsi:type="learningcorpus:MistakeTypeCategory" xmi:id="2b4adfbd-32a3-4e25-b9b3-5139f18c7709" name="Relationship mistakes" subcategories="47529b9e-7489-4bba-a712-f172882d18e0 e3c76b6d-239e-4173-a0e6-34cc9168a771 7b7c91af-1cdf-4d57-beee-db8d3157c8f5"/>
+  <mistakeTypeCategories xsi:type="learningcorpus:MistakeTypeCategory" xmi:id="718088f0-6dc2-4aee-b502-9f0360ee3018" name="Design pattern mistakes" subcategories="85e20f98-0a13-407a-9cd3-fc507d05ac36 0cb1ac52-91b8-4b1f-b733-90de9b451afa"/>
+  <mistakeTypeCategories xsi:type="learningcorpus:MistakeTypeCategory" xmi:id="8d72fe7f-4b46-46b8-bd89-9053127aec11" name="Class name mistakes" supercategory="b31a9f23-222e-407d-bdc6-10c8ec3e27c5">
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="515c5b75-c229-4ec4-9095-7026af09de02" name="Plural class name" description="Plural class name" priority="3"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="f0ada40e-7744-403e-a87b-c72dc01240df" name="Lowercase class name" description="Lowercase class name" priority="2"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="8ba4f147-ac7b-4206-b277-c01db05094b5" name="Software engineering term" priority="4" atomic="true" description="Software engineering term" feedbacks="8697d752-bc83-4cba-8274-f485677776ea 1a3c9f30-4918-4d57-a219-a09a9cbe67ed 5ef7c09c-e31b-4f93-8655-4cbf93ef34d3 65020d68-1a83-412e-a06c-e38961d3a096"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="cc60d528-cb5c-4f19-970c-44c4b90a74a2" name="Bad class name spelling" priority="1" atomic="true" description="Bad class name spelling" feedbacks="d1fd2906-0180-4fc3-bf1d-5ca5235d0fd8 ac6c83c1-2cd0-44d1-92a2-652385b823d0 600df96b-0c37-4b8d-adb8-e81c7df8f505 5a3b0496-eb0c-49d0-b76c-41a57fbb85c4"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="b80fa654-1c6b-4cc6-8469-acb049a1154e" name="Similar (yet incorrect) class name" description="Similar (yet incorrect) class name" priority="5"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="77a40e55-2269-40e1-869f-8f4093f995da" name="Wrong class name" description="Wrong class name" priority="6"/>
   </mistakeTypeCategories>
-  <mistakeTypeCategories xsi:type="learningcorpus:MistakeTypeCategory" xmi:id="3676ad67-4716-46d7-99ab-608f2f1c35fc" name="Enumeration mistakes" supercategory="896b9d6a-9c22-4c6d-adb7-cc93f2fe3095">
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="c2483f01-d464-4bac-86d6-fd3ba8ad4a5d" name="Class should be enum" description="Regular class should be enumeration" priority="11"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="e94df1f7-76fc-40dc-8ec1-7f7c9c14a6d4" name="Enum should be class" description="Enumeration should be regular class" priority="12"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="dec84b19-9d07-4663-a864-8132a8a37064" name="Missing enum" description="Missing enumeration" priority="86"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="4656a127-1eb1-4783-ad6b-c992b2eec6c9" name="Extra enum" description="Extra enumeration" priority="72"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="2b7c4fc5-a4ce-4bca-bbe1-f70ed2852ea9" name="Bad enum name spelling" description="Bad enumeration name spelling" priority="13"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="07f1b1e2-3c3d-4ff1-8760-aa3894ecc34e" name="Similar enum name" description="Similar enumeration name" priority="15"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="77c6b3a3-c462-49c5-9abb-f5f99c9eb2de" name="Missing enum item" description="Missing enumeration item" priority="87"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="83f44d5f-d806-4569-95e4-cbf5fb474f15" name="Extra enum item" description="Extra enumeration item" priority="73"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="675ad901-e0cc-4c50-b189-73866ab71bd9" name="Bad enum item spelling" description="Bad enumeration item spelling" priority="14"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="b8de347a-a68b-45bf-804e-0ad591b8d727" name="Similar enum item" description="Similar enumeration item" priority="16"/>
+  <mistakeTypeCategories xsi:type="learningcorpus:MistakeTypeCategory" xmi:id="86ba721d-9858-41df-811a-ca50d807a9e5" name="Enumeration mistakes" supercategory="b31a9f23-222e-407d-bdc6-10c8ec3e27c5">
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="75aba224-4955-4f15-8df8-0e68f3f97dbf" name="Class should be enum" description="Regular class should be enumeration" priority="11"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="c3f64a07-bcbc-43ec-91ea-dc93ca88a622" name="Enum should be class" description="Enumeration should be regular class" priority="12"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="ab5432b0-6fc9-4821-9fc9-ab2d40113bda" name="Missing enum" description="Missing enumeration" priority="86"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="3686321c-a60b-4a71-86ba-196bba79c909" name="Extra enum" description="Extra enumeration" priority="72"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="33704ca5-8817-45c1-972a-4467af142809" name="Bad enum name spelling" description="Bad enumeration name spelling" priority="13"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="d11c33b2-b929-4b4f-b732-bcac867713f4" name="Similar enum name" description="Similar enumeration name" priority="15"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="b198a803-1169-4e3c-8fc1-0ae8580450d1" name="Missing enum item" description="Missing enumeration item" priority="87"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="613e575c-b2f9-452a-8548-01452fe21242" name="Extra enum item" description="Extra enumeration item" priority="73"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="728b38d3-b0eb-4290-9e8f-0403f6c6b8b9" name="Bad enum item spelling" description="Bad enumeration item spelling" priority="14"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="f10d94bc-da5b-4f6d-b8b2-fe774b02a736" name="Similar enum item" description="Similar enumeration item" priority="16"/>
   </mistakeTypeCategories>
-  <mistakeTypeCategories xsi:type="learningcorpus:MistakeTypeCategory" xmi:id="6b5c70ef-a6d6-4bf4-9564-ee07adf21f53" name="Extra attribute mistakes" supercategory="49ca5132-bf3a-4a9b-a6c6-4ae984fad5b2">
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="0c92c131-f322-42e6-ad5c-20bc3349e598" name="Plural attribute" description="Plural attribute" priority="19"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="b3550ce4-8ec2-4371-8724-ae760240f1c8" name="List attribute" description="List attribute" priority="28"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="97babc78-9faa-4181-b8dd-5af3e3144b50" name="Extra attribute" description="Extra attribute" priority="81"/>
+  <mistakeTypeCategories xsi:type="learningcorpus:MistakeTypeCategory" xmi:id="61f4ec2c-0112-403e-a722-0ec17b599002" name="Extra attribute mistakes" supercategory="2898ce55-93b3-406f-9720-0920e2fb89b8">
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="9971ae03-1255-4147-88fc-e46c9641863c" name="Plural attribute" description="Plural attribute" priority="19"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="8eeb5b57-c0ce-4295-a046-8dee3e013ce0" name="List attribute" description="List attribute" priority="28"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="60f358c5-6455-46a0-9bfe-5f2044749b78" name="Extra attribute" description="Extra attribute" priority="81"/>
   </mistakeTypeCategories>
-  <mistakeTypeCategories xsi:type="learningcorpus:MistakeTypeCategory" xmi:id="ca815b3b-891f-420b-867b-2f221c419b5c" name="Wrong attribute name mistakes" supercategory="49ca5132-bf3a-4a9b-a6c6-4ae984fad5b2">
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="777f52a3-fe3f-495b-8477-df14e0371987" name="Bad attribute name spelling" description="Bad attribute name spelling" priority="17"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="d6d3de93-4bcc-4a23-97d4-2db7345aafc4" name="Uppercase attribute name" description="Uppercase attribute name" priority="18"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="46692b93-1518-4f3c-a4ec-d17f48c8ec22" name="Similar (yet incorrect) attribute name" description="Similar (yet incorrect) attribute name" priority="20"/>
+  <mistakeTypeCategories xsi:type="learningcorpus:MistakeTypeCategory" xmi:id="6364c3bd-1053-4a7c-aa79-68bd689427cc" name="Wrong attribute name mistakes" supercategory="2898ce55-93b3-406f-9720-0920e2fb89b8">
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="22c86679-a7f7-4a1f-be91-c9076e738e83" name="Bad attribute name spelling" description="Bad attribute name spelling" priority="17"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="07330c16-ed90-4ddf-a549-853e691f56dd" name="Uppercase attribute name" description="Uppercase attribute name" priority="18"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="9fb2087a-e539-47fd-b546-a1b12633d56b" name="Similar (yet incorrect) attribute name" description="Similar (yet incorrect) attribute name" priority="20"/>
   </mistakeTypeCategories>
-  <mistakeTypeCategories xsi:type="learningcorpus:MistakeTypeCategory" xmi:id="5ac746b4-b118-4564-9424-8692b44d1e4a" name="Attribute in wrong class mistakes" supercategory="49ca5132-bf3a-4a9b-a6c6-4ae984fad5b2">
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="38db68ff-d4b5-4759-86dc-0ade98be3655" name="Attribute misplaced" description="Attribute misplaced" priority="21"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="0a03256f-cb74-40c8-a0ed-1cfa4a324500" name="Attribute duplicated" description="Attribute duplicated" priority="80"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="055a5b44-e47b-4d84-8dd1-476dd44295fb" name="Attribute misplaced in generalization hierarchy" description="Attribute misplaced in generalization hierarchy" priority="29"/>
+  <mistakeTypeCategories xsi:type="learningcorpus:MistakeTypeCategory" xmi:id="f7144ce9-ccc4-418e-9916-ec74f26806da" name="Attribute in wrong class mistakes" supercategory="2898ce55-93b3-406f-9720-0920e2fb89b8">
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="84330389-d504-42ba-a9dd-5ddf47039316" name="Attribute misplaced" description="Attribute misplaced" priority="21"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="4d84c1a1-b96f-42a2-bdbc-9363df52068f" name="Attribute duplicated" description="Attribute duplicated" priority="80"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="20c7297a-4a28-4c56-a3b3-ff0d44df427c" name="Attribute misplaced in generalization hierarchy" description="Attribute misplaced in generalization hierarchy" priority="29"/>
   </mistakeTypeCategories>
-  <mistakeTypeCategories xsi:type="learningcorpus:MistakeTypeCategory" xmi:id="f1b1b650-3e9a-4305-915f-9fbc8b0af2e2" name="Missing association mistakes" supercategory="01925285-d1d6-4e9f-a913-7743377d1543">
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="92e2234a-379b-411f-828e-b3d6ee705ebf" name="Missing association" description="Missing association" priority="90"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="77faf589-196d-4620-871b-7c16fcf52aea" name="Missing aggregation" description="Missing aggregation" priority="91"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="b6c9b127-6b7e-4127-beaa-27f3b82be148" name="Missing n-ary association" description="Missing n-ary association" priority="92"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="3401656c-4f65-43c5-bfdc-d18c0a4c990c" name="Using attribute instead of assoc" description="Using attribute instead of association" priority="27"/>
+  <mistakeTypeCategories xsi:type="learningcorpus:MistakeTypeCategory" xmi:id="16d9f11a-4f2d-4cac-9a71-d68819c2bc49" name="Missing association mistakes" supercategory="47529b9e-7489-4bba-a712-f172882d18e0">
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="8d53615a-1df9-4d22-a708-441f8c9c3fee" name="Missing association" description="Missing association" priority="90"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="d19d2940-5261-46b6-9b35-2301973e6e9d" name="Missing aggregation" description="Missing aggregation" priority="91"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="9d9738c4-b131-48db-a089-e16be293379b" name="Missing n-ary association" description="Missing n-ary association" priority="92"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="5df773d1-517d-460d-8ca9-cbfeb13aa527" name="Using attribute instead of assoc" description="Using attribute instead of association" priority="27"/>
   </mistakeTypeCategories>
-  <mistakeTypeCategories xsi:type="learningcorpus:MistakeTypeCategory" xmi:id="21add104-a645-41cc-a5ae-f55793d66061" name="Extra association mistakes" supercategory="01925285-d1d6-4e9f-a913-7743377d1543">
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="5a054b68-4362-42ad-839a-ab2194787c02" name="Representing action with assoc" description="Representing an action with an association" priority="76"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="77b605bc-27a0-474d-a04c-52e61fd2dbc9" name="Composed part contained in more than one parent" description="Composed part contained in more than one parent" priority="26"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="77a478f3-f3f9-4143-ba6e-87931e9b0c57" name="Extra association" description="Extra association" priority="77"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="b2d6531a-a07c-4881-a497-879f1a710d8e" name="Extra aggregation" description="Extra aggregation" priority="78"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="ca2960f6-4f0b-47ba-9ed8-7ce2578ca386" name="Extra n-ary association" description="Extra n-ary association" priority="79"/>
+  <mistakeTypeCategories xsi:type="learningcorpus:MistakeTypeCategory" xmi:id="9b49d890-8b22-4f8b-ae79-c1a9f50916b0" name="Extra association mistakes" supercategory="47529b9e-7489-4bba-a712-f172882d18e0">
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="41a1410e-36a5-44f1-8c1b-fa07a1550be4" name="Representing action with assoc" description="Representing an action with an association" priority="76"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="cbacc348-2919-4523-9a1a-c0a42238e48f" name="Composed part contained in more than one parent" description="Composed part contained in more than one parent" priority="26"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="5c3c48b3-7c2e-4e87-b53a-551a5ede15e4" name="Extra association" description="Extra association" priority="77"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="36c5b303-ec1f-476f-afaa-1d82a043ad9c" name="Extra aggregation" description="Extra aggregation" priority="78"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="a9d2469a-4158-413b-9c7e-899457e40e02" name="Extra n-ary association" description="Extra n-ary association" priority="79"/>
   </mistakeTypeCategories>
-  <mistakeTypeCategories xsi:type="learningcorpus:MistakeTypeCategory" xmi:id="6beca509-97c1-4c26-9928-e42881367da2" name="Association type mistakes" supercategory="01925285-d1d6-4e9f-a913-7743377d1543">
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="e9c34137-7a83-4c69-a509-f604c9fe023f" name="Using aggregation/composition instead of assoc" description="Using aggregation/composition instead of association" priority="32"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="b24e24bf-240a-48a9-a92a-5f295ee59dfb" name="Using directed assoc instead of undirected" description="Using directed association instead of undirected association" priority="33"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="babdd8dd-bb57-423b-8e76-5ef2833c5029" name="Using undirected assoc instead of directed" description="Using undirected association instead of directed association" priority="34"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="596ec557-1e51-4be9-a595-7da5a14f2cda" name="Using composition instead of aggregation" description="Using composition instead of aggregation" priority="36"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="a299b3df-636a-48b7-a772-a07946f033a5" name="Using binary assoc instead of n-ary assoc" description="Using binary association instead of n-ary association" priority="37"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="1439f226-87f1-4195-9292-cde577a6ecea" name="Using n-ary assoc instead of binary assoc" description="Using n-ary association instead of binary association" priority="38"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="8c05104b-8b3e-4756-a742-9e5a41a4b312" name="Using intermediate class instead of n-ary assoc" description="Using intermediate class instead of n-ary association" priority="40"/>
+  <mistakeTypeCategories xsi:type="learningcorpus:MistakeTypeCategory" xmi:id="8bdf23be-9c42-431a-bfd1-9af6ec98cc12" name="Association type mistakes" supercategory="47529b9e-7489-4bba-a712-f172882d18e0">
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="6a0bf462-f6f7-4865-8d5f-06c22b977505" name="Using aggregation/composition instead of assoc" description="Using aggregation/composition instead of association" priority="32"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="87bb5ea7-f06b-4cae-8903-1f5db5e2e219" name="Using directed assoc instead of undirected" description="Using directed association instead of undirected association" priority="33"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="9190745b-7da1-41bd-9586-2e5a7e207145" name="Using undirected assoc instead of directed" description="Using undirected association instead of directed association" priority="34"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="19553101-9b67-4e6b-a765-c70b241006c9" name="Using composition instead of aggregation" description="Using composition instead of aggregation" priority="36"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="0960fb5b-7f18-46c9-bfae-fc7ece0d94a5" name="Using binary assoc instead of n-ary assoc" description="Using binary association instead of n-ary association" priority="37"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="5a25ffa8-aa17-4131-b89e-a20804d1dfcf" name="Using n-ary assoc instead of binary assoc" description="Using n-ary association instead of binary association" priority="38"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="758ae4fa-20ce-4162-9000-3eb6b5eae075" name="Using intermediate class instead of n-ary assoc" description="Using intermediate class instead of n-ary association" priority="40"/>
   </mistakeTypeCategories>
-  <mistakeTypeCategories xsi:type="learningcorpus:MistakeTypeCategory" xmi:id="927feab0-8077-4fb3-8468-1037786823cb" name="Association name mistakes" supercategory="01925285-d1d6-4e9f-a913-7743377d1543">
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="ac1e139f-20dc-4cc7-8b57-bb3b18c07576" name="Missing association name" description="Missing association name when one was expected" priority="94"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="dd07cbf2-7402-41e9-93f5-bef192a1c4c5" name="Bad association name spelling" description="Bad association name spelling" priority="55"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="0b5844b6-b909-49af-898d-5aa30f57be4d" name="Similar (yet incorrect) association name" description="Similar (yet incorrect) association name" priority="56"/>
+  <mistakeTypeCategories xsi:type="learningcorpus:MistakeTypeCategory" xmi:id="9683f76a-9c9f-404a-a587-9ec46642da8d" name="Association name mistakes" supercategory="47529b9e-7489-4bba-a712-f172882d18e0">
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="c610f3d7-b77d-49cd-ab40-439a0aa2c9ae" name="Missing association name" description="Missing association name when one was expected" priority="94"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="aba92982-3076-4bd7-b69c-381bd402742f" name="Bad association name spelling" description="Bad association name spelling" priority="55"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="300a56d0-25fb-4ba7-9cac-ecb54cafd3d7" name="Similar (yet incorrect) association name" description="Similar (yet incorrect) association name" priority="56"/>
   </mistakeTypeCategories>
-  <mistakeTypeCategories xsi:type="learningcorpus:MistakeTypeCategory" xmi:id="f75218a0-3643-438b-8082-f73c8891244e" name="Multiplicity mistakes" supercategory="01925285-d1d6-4e9f-a913-7743377d1543">
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="82aab433-2c54-46ff-b6d6-974c65c0dece" name="Infinite recursive dependency" description="Infinite recursive dependency" priority="25"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="63ec7a9b-cac9-4a79-841a-73fdf0193b1b" name="Wrong multiplicity" description="Wrong multiplicity" priority="47"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="bf77e7cd-ef43-461c-a0eb-8ced5a929ac9" name="Missing multiplicity" description="Missing multiplicity" priority="48"/>
+  <mistakeTypeCategories xsi:type="learningcorpus:MistakeTypeCategory" xmi:id="b0e9d203-b073-4e34-9045-517c45bc75b6" name="Multiplicity mistakes" supercategory="47529b9e-7489-4bba-a712-f172882d18e0">
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="3235eb92-bb97-4774-82a8-4c851448cd97" name="Infinite recursive dependency" description="Infinite recursive dependency" priority="25"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="f354c25e-b5e2-4c60-9739-94fa04a462b8" name="Wrong multiplicity" description="Wrong multiplicity" priority="47"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="d28d239a-bf05-4148-af99-86397bbf8922" name="Missing multiplicity" description="Missing multiplicity" priority="48"/>
   </mistakeTypeCategories>
-  <mistakeTypeCategories xsi:type="learningcorpus:MistakeTypeCategory" xmi:id="cbce7443-0295-4a69-a614-38a2f9a17f79" name="Role name mistakes" supercategory="01925285-d1d6-4e9f-a913-7743377d1543">
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="dfedb7e9-f1be-48f1-9ca2-76eb8dbc734e" name="Missing role names" description="Missing role names" priority="93"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="756c8d03-342f-422b-9091-488dcf90fc37" name="Role should be static" description="Role should be static" priority="54"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="a6b8c468-6fb0-49d0-b445-ab20b9450b5a" name="Role should not be static" description="Role should not be static" priority="53"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="3d4cfb2f-c5f2-46e7-99e3-eb36b24eaa65" name="Bad role name spelling" description="Bad role name spelling" priority="50"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="a1be5469-86b3-412b-91a8-4ffe85b4e552" name="Similar (yet incorrect) role name" description="Similar (yet incorrect) role name" priority="51"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="4e552445-2128-4a41-9102-9731393b6aed" name="Wrong role name" description="Wrong role name but correct association" priority="52"/>
+  <mistakeTypeCategories xsi:type="learningcorpus:MistakeTypeCategory" xmi:id="ff8e98b2-800e-4ff4-a683-3a2074bfeab8" name="Role name mistakes" supercategory="47529b9e-7489-4bba-a712-f172882d18e0">
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="423e01a4-9374-4332-980a-ddd365fd9f1c" name="Missing role names" description="Missing role names" priority="93"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="de924e88-a398-4d1b-8c2f-98555f1d5505" name="Role should be static" description="Role should be static" priority="54"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="d95bfb54-b581-42ed-b29d-4e7d2bd0fa95" name="Role should not be static" description="Role should not be static" priority="53"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="fcf30517-2481-4c6b-a288-723f3e19d8ba" name="Bad role name spelling" description="Bad role name spelling" priority="50"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="d15127bc-a4a5-4df2-9a54-bdaa7bd15c88" name="Similar (yet incorrect) role name" description="Similar (yet incorrect) role name" priority="51"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="f9440958-f002-4142-81f3-3ad46a80cff8" name="Wrong role name" description="Wrong role name but correct association" priority="52"/>
   </mistakeTypeCategories>
-  <mistakeTypeCategories xsi:type="learningcorpus:MistakeTypeCategory" xmi:id="d023565e-3664-43ed-ba70-2d90e85a6bd7" name="Association class mistakes" supercategory="01925285-d1d6-4e9f-a913-7743377d1543">
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="f88028c1-08da-4cd0-8dc2-513279e08c8f" name="Missing assoc class" description="Missing association class" priority="85"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="03d520ba-b1d6-447b-a194-34f2a63f1177" name="Extra assoc class" description="Extra association class" priority="71"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="c55bf110-6bc4-4227-9cbb-a054834ea2f3" name="Bad assoc class name spelling" description="Bad association class name spelling" priority="7"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="2fc4007e-f631-4c0b-ad0c-55706abf66ab" name="Assoc class should be class" description="Association class should be regular class" priority="9"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="93aca05d-5180-41b8-b144-2c7235930528" name="Class should be assoc class" description="Regular class should be association class" priority="10"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="c2ef2851-c044-4b02-ab17-3ee028682052" name="Similar assoc class name" description="Similar (yet incorrect) association class name" priority="8"/>
+  <mistakeTypeCategories xsi:type="learningcorpus:MistakeTypeCategory" xmi:id="c5234556-c12d-4724-b998-861a865abb4c" name="Association class mistakes" supercategory="47529b9e-7489-4bba-a712-f172882d18e0">
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="9b1f920b-df9b-4d7c-888d-1e8322e42ae8" name="Missing assoc class" description="Missing association class" priority="85"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="8ed63016-9fef-43c8-ad91-b1c55f9d6f7d" name="Extra assoc class" description="Extra association class" priority="71"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="ebb8664b-c32b-4d22-8d68-9ba080c760e9" name="Bad assoc class name spelling" description="Bad association class name spelling" priority="7"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="f9e4c1a3-a563-4a74-b9dc-94ace0ceaf00" name="Assoc class should be class" description="Association class should be regular class" priority="9"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="a71736e4-49bd-4172-9ff7-110f5198095d" name="Class should be assoc class" description="Regular class should be association class" priority="10"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="cdedcb67-1a36-4647-b519-36c7ddc7aa10" name="Similar assoc class name" description="Similar (yet incorrect) association class name" priority="8"/>
   </mistakeTypeCategories>
-  <mistakeTypeCategories xsi:type="learningcorpus:MistakeTypeCategory" xmi:id="01925285-d1d6-4e9f-a913-7743377d1543" name="Association mistakes" subcategories="f1b1b650-3e9a-4305-915f-9fbc8b0af2e2 21add104-a645-41cc-a5ae-f55793d66061 6beca509-97c1-4c26-9928-e42881367da2 927feab0-8077-4fb3-8468-1037786823cb f75218a0-3643-438b-8082-f73c8891244e cbce7443-0295-4a69-a614-38a2f9a17f79 d023565e-3664-43ed-ba70-2d90e85a6bd7" supercategory="6cb11c42-b499-49d0-a79e-562307e79b70"/>
-  <mistakeTypeCategories xsi:type="learningcorpus:MistakeTypeCategory" xmi:id="1f32caa0-8baa-4c01-8db3-04e2ce461269" name="Composition mistakes" supercategory="6cb11c42-b499-49d0-a79e-562307e79b70">
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="61e34391-50da-4ee0-8a6a-32cb1f9448bb" name="Missing composition" description="Missing composition" priority="89"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="602e7a92-6d8b-46c8-acda-2fd2dde7f884" name="Extra composition" description="Extra composition" priority="75"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="429b4156-ae62-4d6e-9bf5-7b7e1088013f" name="Using association instead of aggregation/composition" description="Using association instead of aggregation/composition" priority="31"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="0e8d6c0e-994e-4a44-a2fb-c50d358e0206" name="Using aggregation instead of composition" description="Using aggregation instead of composition" priority="35"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="e3f21208-f1e2-4ca6-b8bb-5136ab8d5565" name="Incomplete containment tree" description="Incomplete containment tree" priority="57"/>
+  <mistakeTypeCategories xsi:type="learningcorpus:MistakeTypeCategory" xmi:id="47529b9e-7489-4bba-a712-f172882d18e0" name="Association mistakes" subcategories="16d9f11a-4f2d-4cac-9a71-d68819c2bc49 9b49d890-8b22-4f8b-ae79-c1a9f50916b0 8bdf23be-9c42-431a-bfd1-9af6ec98cc12 9683f76a-9c9f-404a-a587-9ec46642da8d b0e9d203-b073-4e34-9045-517c45bc75b6 ff8e98b2-800e-4ff4-a683-3a2074bfeab8 c5234556-c12d-4724-b998-861a865abb4c" supercategory="2b4adfbd-32a3-4e25-b9b3-5139f18c7709"/>
+  <mistakeTypeCategories xsi:type="learningcorpus:MistakeTypeCategory" xmi:id="e3c76b6d-239e-4173-a0e6-34cc9168a771" name="Composition mistakes" supercategory="2b4adfbd-32a3-4e25-b9b3-5139f18c7709">
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="8066b5e2-27bd-4cac-b59d-53798758b4dd" name="Missing composition" description="Missing composition" priority="89"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="ba4557bd-c1a1-426c-88e4-39f1c2335aee" name="Extra composition" description="Extra composition" priority="75"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="b7946fed-25a5-4865-b6a1-529cd0be8468" name="Using association instead of aggregation/composition" description="Using association instead of aggregation/composition" priority="31"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="4467a94c-8cda-4359-b03c-df13e961ddce" name="Using aggregation instead of composition" description="Using aggregation instead of composition" priority="35"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="a60d03b5-bb8c-4faa-9d4c-c5135275ebc7" name="Incomplete containment tree" description="Incomplete containment tree" priority="57"/>
   </mistakeTypeCategories>
-  <mistakeTypeCategories xsi:type="learningcorpus:MistakeTypeCategory" xmi:id="e4ab00e6-f548-47e8-9520-f14f0aa9df86" name="Generalization mistakes" supercategory="6cb11c42-b499-49d0-a79e-562307e79b70">
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="82a303d9-45fc-4ee3-a56d-d971ee717897" name="Missing generalization" description="Missing generalization" priority="88"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="9f85e3c5-1c82-4468-bbf6-0aca9c427b36" name="Extra generalization" description="Extra generalization" priority="74"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="d46d31f5-52a0-4e20-bd54-162628188c93" name="Generalization inapplicable" description="Generalization does not follow isA rule" priority="30"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="70875708-af1a-4b34-b55c-3096def79977" name="Subclass not distinct across lifetime" description="Subclass not distinct across lifetime" priority="45"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="cf334f32-f204-45d3-9c59-c4c9e79596bb" name="Inherited feature does not make sense for subclass" description="Inherited feature does not make sense for subclass" priority="46"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="43bb9471-211e-4c49-a182-e9d71e36e416" name="Subclass is an instance of superclass" description="Subclass is an instance of superclass" priority="43"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="b35b6878-81a7-484c-9b07-b5cb06266ec7" name="Non-differentiated subclass" description="Non-differentiated subclass" priority="44"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="48dc3360-35cf-4672-8624-36f20bf5a3f4" name="Wrong generalization direction" description="Wrong generalization direction" priority="41"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="4e4d00c4-0d0e-4674-81ba-6fb4de4b28c4" name="Wrong superclass" description="Wrong superclass" priority="42"/>
+  <mistakeTypeCategories xsi:type="learningcorpus:MistakeTypeCategory" xmi:id="7b7c91af-1cdf-4d57-beee-db8d3157c8f5" name="Generalization mistakes" supercategory="2b4adfbd-32a3-4e25-b9b3-5139f18c7709">
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="64108d1f-6efe-4184-b8bd-80221f60c459" name="Missing generalization" description="Missing generalization" priority="88"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="15c523cd-fc49-4d9f-8354-dade839d1c86" name="Extra generalization" description="Extra generalization" priority="74"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="7ba33276-aede-44ad-9226-0f1f8d58a973" name="Generalization inapplicable" description="Generalization does not follow isA rule" priority="30"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="5bb353c4-a767-445a-b68d-e299f36e7bf5" name="Subclass not distinct across lifetime" description="Subclass not distinct across lifetime" priority="45"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="eb107bff-03a3-4431-9606-6e136ee59c3e" name="Inherited feature does not make sense for subclass" description="Inherited feature does not make sense for subclass" priority="46"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="981cd9a3-6238-48f9-a50a-91046ca34e23" name="Subclass is an instance of superclass" description="Subclass is an instance of superclass" priority="43"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="0c8d777b-494b-46e5-a323-4445bac1ad4b" name="Non-differentiated subclass" description="Non-differentiated subclass" priority="44"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="306f40bc-3c40-494c-b558-abda1bd8155f" name="Wrong generalization direction" description="Wrong generalization direction" priority="41"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="b8365045-4b4a-4e3c-970c-bc7382127949" name="Wrong superclass" description="Wrong superclass" priority="42"/>
   </mistakeTypeCategories>
-  <mistakeTypeCategories xsi:type="learningcorpus:MistakeTypeCategory" xmi:id="d4f87c9d-3a62-40be-88b8-fedce33fb4ab" name="Using different Player-Role pattern" supercategory="c3c80734-4295-4c3c-8860-531118769d36">
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="a6f11b1b-47ef-4bd0-8f4b-79ff16c1f2de" name="Subclass should be full PR pattern" description="Subclass should be full Player-Role pattern" priority="58"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="d908be88-fa80-46bb-a9d2-f046254dc0d9" name="Subclass should be assoc PR pattern" description="Subclass should be association Player-Role pattern" priority="59"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="25c845b0-746f-47e8-907f-dac794bba4fb" name="Subclass should be enum PR pattern" description="Subclass should be enumeration Player-Role pattern" priority="60"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="19525361-0204-4228-adc2-7862be017a5d" name="Assoc should be full PR pattern" description="Association should be full Player-Role pattern" priority="61"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="28a45f88-6819-4d00-a214-27a2729ac829" name="Assoc should be subclass PR pattern" description="Association should be subclass Player-Role pattern" priority="62"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="b4ee44de-b6c8-4a14-a5f6-b3e44f1d037c" name="Assoc should be enum PR pattern" description="Association should be enum Player-Role pattern" priority="63"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="bbaf7ecb-b9fd-44fb-bbe6-eb717f163a00" name="Enum should be full PR pattern" description="Enumeration should be full Player-Role pattern" priority="64"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="76e7f31d-7ceb-4397-b552-618a18cb600c" name="Enum should be subclass PR pattern" description="Enumeration should be subclass Player-Role pattern" priority="65"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="87ca3ee6-a7f9-4035-bf05-047c24afc127" name="Enum should be assoc PR pattern" description="Enumeration should be association Player-Role pattern" priority="66"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="94f1f241-dc63-447d-9adf-3235678bb05d" name="Full PR pattern should be subclass" description="Full Player-Role pattern should be subclass" priority="67"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="8cef0850-359b-41e4-bf30-842481d73d91" name="Full PR pattern should be assoc" description="Full Player-Role pattern should be association" priority="68"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="b6d34f67-7636-414a-a7c2-343396098808" name="Full PR pattern should be enum" description="Full Player-Role pattern should be enumeration" priority="69"/>
+  <mistakeTypeCategories xsi:type="learningcorpus:MistakeTypeCategory" xmi:id="ddb07b5d-2e6e-43f9-b12d-2aedfcc2b840" name="Using different Player-Role pattern" supercategory="85e20f98-0a13-407a-9cd3-fc507d05ac36">
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="bd0c69a8-e4d8-45e7-a106-3ff633f11a6c" name="Subclass should be full PR pattern" description="Subclass should be full Player-Role pattern" priority="58"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="38cdab00-c9a4-4590-9767-00b65972391a" name="Subclass should be assoc PR pattern" description="Subclass should be association Player-Role pattern" priority="59"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="bb924fc8-6c89-4a1d-b502-e48037514e04" name="Subclass should be enum PR pattern" description="Subclass should be enumeration Player-Role pattern" priority="60"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="ee2584b8-e638-471c-b068-f28ceb8f2822" name="Assoc should be full PR pattern" description="Association should be full Player-Role pattern" priority="61"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="76817b0a-7279-4a6a-9c77-c6e2c306c6e4" name="Assoc should be subclass PR pattern" description="Association should be subclass Player-Role pattern" priority="62"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="a2ad49e7-4847-4d14-9f76-68c82cbdba07" name="Assoc should be enum PR pattern" description="Association should be enumeration Player-Role pattern" priority="63"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="f19f49ef-bff1-44af-a597-dcd3cbfa16db" name="Enum should be full PR pattern" description="Enumeration should be full Player-Role pattern" priority="64"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="c74c09e7-ee63-49b6-936c-12633d61b1c6" name="Enum should be subclass PR pattern" description="Enumeration should be subclass Player-Role pattern" priority="65"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="680dfa96-b797-4782-bce1-1e62ad5639ce" name="Enum should be assoc PR pattern" description="Enumeration should be association Player-Role pattern" priority="66"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="11c658dd-c5ce-4742-8807-6c9d5c7d6b08" name="Full PR pattern should be subclass" description="Full Player-Role pattern should be subclass" priority="67"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="986c2d95-f4bd-430a-baf8-403d68a97959" name="Full PR pattern should be assoc" description="Full Player-Role pattern should be association" priority="68"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="585707e5-32a1-4062-8cac-99f2a348a93c" name="Full PR pattern should be enum" description="Full Player-Role pattern should be enumeration" priority="69"/>
   </mistakeTypeCategories>
-  <mistakeTypeCategories xsi:type="learningcorpus:MistakeTypeCategory" xmi:id="c3c80734-4295-4c3c-8860-531118769d36" name="Player-Role Pattern mistakes" subcategories="d4f87c9d-3a62-40be-88b8-fedce33fb4ab" supercategory="b9cbe39b-6226-499e-aa27-bdac3dadf059">
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="064720da-c694-4ff0-aaba-f7b7d1abef86" name="Missing PR pattern" description="Missing Player-Role pattern" priority="97"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="d7e3c6f5-fe53-4e3e-9d1f-a5151ed49d11" name="Incomplete PR pattern" description="Incomplete Player-Role pattern" priority="95"/>
+  <mistakeTypeCategories xsi:type="learningcorpus:MistakeTypeCategory" xmi:id="85e20f98-0a13-407a-9cd3-fc507d05ac36" name="Player-Role Pattern mistakes" subcategories="ddb07b5d-2e6e-43f9-b12d-2aedfcc2b840" supercategory="718088f0-6dc2-4aee-b502-9f0360ee3018">
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="7da8cdd6-9e55-4988-9aee-b230170bb126" name="Missing PR pattern" description="Missing Player-Role pattern" priority="97"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="bb6869da-1b19-4386-a7ae-900d114d22f6" name="Incomplete PR pattern" description="Incomplete Player-Role pattern" priority="95"/>
   </mistakeTypeCategories>
-  <mistakeTypeCategories xsi:type="learningcorpus:MistakeTypeCategory" xmi:id="14c8fec2-ac91-428b-bcaa-0af0597a45fa" name="Abstraction-Occurrence pattern mistakes" supercategory="b9cbe39b-6226-499e-aa27-bdac3dadf059">
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="7903e210-d8bb-48d2-a7db-4b6d8a8b6a7a" name="Missing AO pattern" description="Missing Abstraction-Occurrence pattern" priority="98"/>
-    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="255376d5-266e-4bd9-9805-f45a9fa9bb92" name="Incomplete AO pattern" description="Incomplete Abstraction-Occurrence pattern" priority="96"/>
+  <mistakeTypeCategories xsi:type="learningcorpus:MistakeTypeCategory" xmi:id="0cb1ac52-91b8-4b1f-b733-90de9b451afa" name="Abstraction-Occurrence pattern mistakes" supercategory="718088f0-6dc2-4aee-b502-9f0360ee3018">
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="a9a668fb-7727-49fc-804a-a7bf1a6bd05b" name="Missing AO pattern" description="Missing Abstraction-Occurrence pattern" priority="98"/>
+    <mistakeTypes xsi:type="learningcorpus:MistakeType" xmi:id="e531174a-556d-4cf5-95d0-9c92da1f9d20" name="Incomplete AO pattern" description="Incomplete Abstraction-Occurrence pattern" priority="96"/>
   </mistakeTypeCategories>
-  <feedbacks xsi:type="learningcorpus:Feedback" xmi:id="400e1fdd-991a-407e-ae6f-299c43ad9067" level="1" highlightSolution="true" mistakeType="ce5da776-30ee-426c-aa5e-1ef578cda2da"/>
-  <feedbacks xsi:type="learningcorpus:TextResponse" xmi:id="5482bf85-9262-4662-a9bf-21a4cab1a636" text="Make sure you have modeled all the classes in the problem description." level="2" mistakeType="ce5da776-30ee-426c-aa5e-1ef578cda2da"/>
-  <feedbacks xsi:type="learningcorpus:Feedback" xmi:id="c940cc7a-b64b-431e-a07d-e0288ff36b49" level="3" mistakeType="ce5da776-30ee-426c-aa5e-1ef578cda2da" highlightProblem="true"/>
-  <feedbacks xsi:type="learningcorpus:ParametrizedResponse" xmi:id="3b9f7533-7ed8-4c08-9fb1-1aa09b2b933a" text="Remember to add the ${className} class." level="4" mistakeType="ce5da776-30ee-426c-aa5e-1ef578cda2da"/>
-  <feedbacks xsi:type="learningcorpus:Feedback" xmi:id="0b5384d8-35de-40bf-a24f-26c1895ce916" level="1" highlightSolution="true" mistakeType="19f765f4-d93b-4eae-9ed5-5d285e4d8b09"/>
-  <feedbacks xsi:type="learningcorpus:TextResponse" xmi:id="bc609090-604a-4c02-8146-24eebcd3ab51" text="Remember that a domain model should not contain software engineering terms." level="2" mistakeType="19f765f4-d93b-4eae-9ed5-5d285e4d8b09"/>
-  <feedbacks xsi:type="learningcorpus:ParametrizedResponse" xmi:id="f0c6a95c-959c-46b2-aa35-15b27f912946" text="${className} is a software engineering term, which does not belong in a domain model." level="3" mistakeType="19f765f4-d93b-4eae-9ed5-5d285e4d8b09"/>
-  <feedbacks xsi:type="learningcorpus:ResourceResponse" xmi:id="dbaea525-513b-4b4e-8b0b-6f7890bff171" learningResources="793d6d0f-6d6b-45c8-92c5-9c4274a1064e" level="4" mistakeType="19f765f4-d93b-4eae-9ed5-5d285e4d8b09"/>
-  <feedbacks xsi:type="learningcorpus:Feedback" xmi:id="4cddbd28-210a-4ba8-b898-92326286f98f" level="1" highlightSolution="true" mistakeType="64e215eb-3162-4ab2-b1ed-ad62e1a89108"/>
-  <feedbacks xsi:type="learningcorpus:TextResponse" xmi:id="ee7d0cc5-d636-42c7-95ab-2c0e0fab6e1f" text="Can you double check this class name?" level="2" mistakeType="64e215eb-3162-4ab2-b1ed-ad62e1a89108"/>
-  <feedbacks xsi:type="learningcorpus:ParametrizedResponse" xmi:id="e4df4813-371d-460e-b5e6-7212abd8ec79" text="The ${incorrectlySpelledClassName} class has a misspelled name." level="3" mistakeType="64e215eb-3162-4ab2-b1ed-ad62e1a89108"/>
-  <feedbacks xsi:type="learningcorpus:ParametrizedResponse" xmi:id="41cff1b2-d5b3-4562-b644-f304b42a0f3a" text="The ${incorrectlySpelledClassName} class should be changed to ${correctClassName}." level="4" mistakeType="64e215eb-3162-4ab2-b1ed-ad62e1a89108"/>
+  <feedbacks xsi:type="learningcorpus:Feedback" xmi:id="338d5586-ff53-47a1-839c-548135106672" level="1" highlightSolution="true" mistakeType="530aaaf1-64c9-4580-99ce-e2a3738323cc"/>
+  <feedbacks xsi:type="learningcorpus:TextResponse" xmi:id="87a656de-ddf5-432e-9fc8-a01ee89c449c" text="Make sure you have modeled all the classes in the problem description." level="2" mistakeType="530aaaf1-64c9-4580-99ce-e2a3738323cc"/>
+  <feedbacks xsi:type="learningcorpus:Feedback" xmi:id="7ae0fe18-6999-4c05-ad4a-039689454e5a" level="3" mistakeType="530aaaf1-64c9-4580-99ce-e2a3738323cc" highlightProblem="true"/>
+  <feedbacks xsi:type="learningcorpus:ParametrizedResponse" xmi:id="3da0d6c1-4a5c-40df-bc87-f09338cd8a2e" text="Remember to add the ${className} class." level="4" mistakeType="530aaaf1-64c9-4580-99ce-e2a3738323cc"/>
+  <feedbacks xsi:type="learningcorpus:Feedback" xmi:id="8697d752-bc83-4cba-8274-f485677776ea" level="1" highlightSolution="true" mistakeType="8ba4f147-ac7b-4206-b277-c01db05094b5"/>
+  <feedbacks xsi:type="learningcorpus:TextResponse" xmi:id="1a3c9f30-4918-4d57-a219-a09a9cbe67ed" text="Remember that a domain model should not contain software engineering terms." level="2" mistakeType="8ba4f147-ac7b-4206-b277-c01db05094b5"/>
+  <feedbacks xsi:type="learningcorpus:ParametrizedResponse" xmi:id="5ef7c09c-e31b-4f93-8655-4cbf93ef34d3" text="${className} is a software engineering term, which does not belong in a domain model." level="3" mistakeType="8ba4f147-ac7b-4206-b277-c01db05094b5"/>
+  <feedbacks xsi:type="learningcorpus:ResourceResponse" xmi:id="65020d68-1a83-412e-a06c-e38961d3a096" learningResources="f8d2c909-18d0-4339-9ea6-ba51664d7a75" level="4" mistakeType="8ba4f147-ac7b-4206-b277-c01db05094b5"/>
+  <feedbacks xsi:type="learningcorpus:Feedback" xmi:id="d1fd2906-0180-4fc3-bf1d-5ca5235d0fd8" level="1" highlightSolution="true" mistakeType="cc60d528-cb5c-4f19-970c-44c4b90a74a2"/>
+  <feedbacks xsi:type="learningcorpus:TextResponse" xmi:id="ac6c83c1-2cd0-44d1-92a2-652385b823d0" text="Can you double check this class name?" level="2" mistakeType="cc60d528-cb5c-4f19-970c-44c4b90a74a2"/>
+  <feedbacks xsi:type="learningcorpus:ParametrizedResponse" xmi:id="600df96b-0c37-4b8d-adb8-e81c7df8f505" text="The ${incorrectlySpelledClassName} class has a misspelled name." level="3" mistakeType="cc60d528-cb5c-4f19-970c-44c4b90a74a2"/>
+  <feedbacks xsi:type="learningcorpus:ParametrizedResponse" xmi:id="5a3b0496-eb0c-49d0-b76c-41a57fbb85c4" text="The ${incorrectlySpelledClassName} class should be changed to ${correctClassName}." level="4" mistakeType="cc60d528-cb5c-4f19-970c-44c4b90a74a2"/>
 </learningcorpus:LearningCorpus>

--- a/modelingassistant/corpus_descriptions/README_TOC.md
+++ b/modelingassistant/corpus_descriptions/README_TOC.md
@@ -108,7 +108,7 @@
          1. [Subclass should be enumeration Player-Role pattern](#subclass-should-be-enumeration-player-role-pattern)
          1. [Association should be full Player-Role pattern](#association-should-be-full-player-role-pattern)
          1. [Association should be subclass Player-Role pattern](#association-should-be-subclass-player-role-pattern)
-         1. [Association should be enum Player-Role pattern](#association-should-be-enum-player-role-pattern)
+         1. [Association should be enumeration Player-Role pattern](#association-should-be-enumeration-player-role-pattern)
          1. [Enumeration should be full Player-Role pattern](#enumeration-should-be-full-player-role-pattern)
          1. [Enumeration should be subclass Player-Role pattern](#enumeration-should-be-subclass-player-role-pattern)
          1. [Enumeration should be association Player-Role pattern](#enumeration-should-be-association-player-role-pattern)
@@ -426,7 +426,7 @@
 ##### Association should be subclass Player-Role pattern
 
 
-##### Association should be enum Player-Role pattern
+##### Association should be enumeration Player-Role pattern
 
 
 ##### Enumeration should be full Player-Role pattern

--- a/modelingassistant/pythonclient/corpus_definition.py
+++ b/modelingassistant/pythonclient/corpus_definition.py
@@ -228,7 +228,7 @@ corpus = LearningCorpus(mistakeTypeCategories=[
                         d="Association should be subclass Player-Role pattern"),
                     assoc_should_be_enum_pr_pattern := mt(
                         n="Assoc should be enum PR pattern",
-                        d="Association should be enum Player-Role pattern"),
+                        d="Association should be enumeration Player-Role pattern"),
                     enum_should_be_full_pr_pattern := mt(
                         n="Enum should be full PR pattern",
                         d="Enumeration should be full Player-Role pattern"),

--- a/modelingassistant/src/learningcorpus/mistaketypes/MistakeTypes.java
+++ b/modelingassistant/src/learningcorpus/mistaketypes/MistakeTypes.java
@@ -384,7 +384,7 @@ public class MistakeTypes {
   /** The association should be subclass player-role pattern mistake type. */
   public static final MistakeType ASSOC_SHOULD_BE_SUBCLASS_PR_PATTERN = MTS.get("Assoc should be subclass PR pattern");
 
-  /** The association should be enum player-role pattern mistake type. */
+  /** The association should be enumeration player-role pattern mistake type. */
   public static final MistakeType ASSOC_SHOULD_BE_ENUM_PR_PATTERN = MTS.get("Assoc should be enum PR pattern");
 
   /** The enumeration should be full player-role pattern mistake type. */


### PR DESCRIPTION
This PR is the first part of changes to the Learning Corpus. Since this work is large and ongoing, it needs to be divided into multiple parts to remain manageable and to avoid the merge conflicts that occur with giant PRs.

**Summary of changes:**
* Add `MistakeType.description` to learning corpus metamodel
* Deprecate old Learning Corpus DSL (based on Xtext) and transformation (Acceleo)
* Migrate Acceleo/Java logic in `modelingassistant.learningcorpus.dsl.transformation` Eclipse project to Python to allow for faster and more straightforward updates to the corpus
* Refactor Python corpus definition, initialization, and creation logic by separating these tasks into different files. Updating the corpus can now be done by simply running
   ```bash
   python3 modelingassistant/pythonclient/createcorpus.py
   ```
* Update some of the mistake types and categories, including their use in Java and Python source files

There are other changes that we discussed that are not yet implemented. They will follow in a future PR.